### PR TITLE
fix database query

### DIFF
--- a/classes/PublonsReviewsDAO.inc.php
+++ b/classes/PublonsReviewsDAO.inc.php
@@ -211,11 +211,12 @@ class PublonsReviewsDAO extends DAO {
             )
         );
 
-        $returner = isset($result->fields[0]) && $result->fields[0] != 0 ? $result->fields[0] : null;
+        $row = $result->current();
+        $publons_reviews_id = $row ? $row->publons_reviews_id : null;
 
         unset($result);
 
-        return $returner;
+        return $publons_reviews_id;
     }
 
     /**


### PR DESCRIPTION
On step 4 page, if a review has been exported to Publons, it should display a button `This review has been exported to Publons` , this is done by doing a DB query by review id. If a review existing, then display this button, otherwise display a `export to Publons` button. But now the DB query is broken so it always return None which make the page always display the `export to Publons` button.

this pr will fix this problem

![image](https://user-images.githubusercontent.com/21093396/119605559-1dfbe380-be45-11eb-9f53-7eab4b7a8e4b.png)
